### PR TITLE
res_phreaknet: Resolve issue where /var or /tmp are on seperate filesystems.

### DIFF
--- a/res/res_phreaknet.c
+++ b/res/res_phreaknet.c
@@ -853,7 +853,9 @@ static int update_rsa_pubkeys(void)
 			}
 		}
 
-		/* Create file using public key material */
+		/* Create key file using public key material.  We cannot simply use rename here as that
+		   /tmp and /var maybe on seperate file systems.  With systemd tmp_filename is needs to be relative to systemd
+		   private tmp directory */
 		if ((fd = open(key_file, O_WRONLY | O_TRUNC | O_CREAT, AST_FILE_MODE)) < 0) {
 	        	ast_log(LOG_WARNING, "Unable to open %s in write-only mode\n", key_file);
 			unlink(tmp_filename);

--- a/res/res_phreaknet.c
+++ b/res/res_phreaknet.c
@@ -853,11 +853,20 @@ static int update_rsa_pubkeys(void)
 			}
 		}
 
-		if (rename(tmp_filename, key_file)) {
-			ast_log(LOG_WARNING, "Failed to rename new public key file to %s: %s\n", key_file, strerror(errno));
+		/* Create file using public key material */
+		if ((fd = open(key_file, O_WRONLY | O_TRUNC | O_CREAT, AST_FILE_MODE)) < 0) {
+	        	ast_log(LOG_WARNING, "Unable to open %s in write-only mode\n", key_file);
 			unlink(tmp_filename);
 			goto cleanup;
 		}
+		fp = fdopen(fd, "wb");
+		if (!fp) {
+		       	ast_log(LOG_WARNING, "Failed to create key file %s\n", key_file);
+			unlink(tmp_filename);
+			goto cleanup;
+		}
+		fprintf(fp, "%s", key);
+		fclose(fp);
 
 		/* XXX Future improvement would be to delete public keys that no longer exist (and remove from chan_iax2 config) */
 


### PR DESCRIPTION
Resolve issue where /var or /tmp are on seperate filesystems.
ast_filecopy from systemd /tmp fails, as it does not recognize the different root