### PR TITLE
[DAHDI]: Custom reverse patch for kernel.h

### DIFF
--- a/patches/dahdi_pci_module.diff
+++ b/patches/dahdi_pci_module.diff
@@ -1,0 +1,127 @@
+From 4af6f69fff19ea3cfb9ab0ff86a681be86045215 Mon Sep 17 00:00:00 2001
+From: Shaun Ruffell <sruffell@sruffell.net>
+Date: Fri, 11 Jan 2019 04:46:35 +0000
+Subject: [PATCH] Remove unnecessary dahdi_pci_module macro.
+
+All supported kernel variations support the same signature for
+registering a PCI module, so we can eliminate the macro.
+
+Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>
+---
+ drivers/dahdi/wcaxx-base.c      |    2 +-
+ drivers/dahdi/wcb4xxp/base.c    |    2 +-
+ drivers/dahdi/wct4xxp/base.c    |    2 +-
+ drivers/dahdi/wctc4xxp/base.c   |    2 +-
+ drivers/dahdi/wctdm24xxp/base.c |    2 +-
+ drivers/dahdi/wcte13xp-base.c   |    2 +-
+ drivers/dahdi/wcte43x-base.c    |    2 +-
+ include/dahdi/kernel.h          |    2 --
+ 8 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git drivers/dahdi/wcaxx-base.c drivers/dahdi/wcaxx-base.c
+index ed7207a..b934960 100644
+--- drivers/dahdi/wcaxx-base.c
++++ drivers/dahdi/wcaxx-base.c
+@@ -4474,7 +4474,7 @@ static int __init wcaxx_init(void)
+ 	if (!battthresh)
+ 		battthresh = fxo_modes[_opermode].battthresh;
+ 
+-	res = dahdi_pci_module(&wcaxx_driver);
++	res = pci_register_driver(&wcaxx_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wcb4xxp/base.c drivers/dahdi/wcb4xxp/base.c
+index 1f72f14..784929f 100644
+--- drivers/dahdi/wcb4xxp/base.c
++++ drivers/dahdi/wcb4xxp/base.c
+@@ -3672,7 +3672,7 @@ static int __init b4xx_init(void)
+ 		printk(KERN_ERR "%s: ERROR: Could not initialize /proc/%s\n",THIS_MODULE->name, PROCFS_NAME);
+ 	}
+ #endif
+-	if (dahdi_pci_module(&b4xx_driver))
++	if (pci_register_driver(&b4xx_driver))
+ 		return -ENODEV;
+ 
+ 	return 0;
+diff --git drivers/dahdi/wct4xxp/base.c drivers/dahdi/wct4xxp/base.c
+index c1d9612..4d0c769 100644
+--- drivers/dahdi/wct4xxp/base.c
++++ drivers/dahdi/wct4xxp/base.c
+@@ -5543,7 +5543,7 @@ static int __init t4_init(void)
+ 			"Please use 'default_linemode' instead.\n");
+ 	}
+ 
+-	res = dahdi_pci_module(&t4_driver);
++	res = pci_register_driver(&t4_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wctc4xxp/base.c drivers/dahdi/wctc4xxp/base.c
+index 54e28d3..3bd56d1 100644
+--- drivers/dahdi/wctc4xxp/base.c
++++ drivers/dahdi/wctc4xxp/base.c
+@@ -4236,7 +4236,7 @@ static int __init wctc4xxp_init(void)
+ 		return -ENOMEM;
+ 	spin_lock_init(&wctc4xxp_list_lock);
+ 	INIT_LIST_HEAD(&wctc4xxp_list);
+-	res = dahdi_pci_module(&wctc4xxp_driver);
++	res = pci_register_driver(&wctc4xxp_driver);
+ 	if (res) {
+ 		kmem_cache_destroy(cmd_cache);
+ 		return -ENODEV;
+diff --git drivers/dahdi/wctdm24xxp/base.c drivers/dahdi/wctdm24xxp/base.c
+index d2e481a..16bf384 100644
+--- drivers/dahdi/wctdm24xxp/base.c
++++ drivers/dahdi/wctdm24xxp/base.c
+@@ -6102,7 +6102,7 @@ static int __init wctdm_init(void)
+ 
+ 	b400m_module_init();
+ 
+-	res = dahdi_pci_module(&wctdm_driver);
++	res = pci_register_driver(&wctdm_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wcte13xp-base.c drivers/dahdi/wcte13xp-base.c
+index 25d4e31..b5f8043 100644
+--- drivers/dahdi/wcte13xp-base.c
++++ drivers/dahdi/wcte13xp-base.c
+@@ -2788,7 +2788,7 @@ static int __init te13xp_init(void)
+ 		return -EINVAL;
+ 	}
+ 
+-	res = dahdi_pci_module(&te13xp_driver);
++	res = pci_register_driver(&te13xp_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wcte43x-base.c drivers/dahdi/wcte43x-base.c
+index 722d18d..45b0f6c 100644
+--- drivers/dahdi/wcte43x-base.c
++++ drivers/dahdi/wcte43x-base.c
+@@ -3612,7 +3612,7 @@ static int __init t43x_init(void)
+ 		return -EINVAL;
+ 	}
+ 
+-	res = dahdi_pci_module(&t43x_driver);
++	res = pci_register_driver(&t43x_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git include/dahdi/kernel.h include/dahdi/kernel.h
+index eb3f691..1b4ba10 100644
+--- include/dahdi/kernel.h
++++ include/dahdi/kernel.h
+@@ -58,8 +58,6 @@
+
+ #include <linux/poll.h>
+
+-#define dahdi_pci_module pci_register_driver
+-
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+ #define HAVE_NET_DEVICE_OPS
+ #endif
+-- 
+1.7.9.5
+


### PR DESCRIPTION
DAHDI 3.2 kernel.h does not include CONFIG_PCI so patch 4af6f69fff19ea3cfb9ab0ff86a681be86045215 fails

Move this is to a custom reverse patch.

Update phreaknet.sh to 2.2