### PR TITLE
[DAHDI]: kernel.h also found in patch cdd6ddd0fd08cb8b7313b16074882439fbb58045

### DIFF
--- a/patches/dahdi_irq_handler.diff
+++ b/patches/dahdi_irq_handler.diff
@@ -1,0 +1,93 @@
+From cdd6ddd0fd08cb8b7313b16074882439fbb58045 Mon Sep 17 00:00:00 2001
+From: Shaun Ruffell <sruffell@sruffell.net>
+Date: Fri, 11 Jan 2019 04:43:26 +0000
+Subject: [PATCH] Remove unnecessary DAHDI_IRQ_HANDLER macro.
+
+All supported kernels now use the same signature for the IRQ handler.
+
+Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>
+---
+ drivers/dahdi/wcb4xxp/base.c  |    2 +-
+ drivers/dahdi/wct4xxp/base.c  |    4 ++--
+ drivers/dahdi/wctc4xxp/base.c |    2 +-
+ drivers/dahdi/wcxb.c          |    2 +-
+ include/dahdi/kernel.h        |    2 --
+ 5 files changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/dahdi/wcb4xxp/base.c b/drivers/dahdi/wcb4xxp/base.c
+index 5fe6fb2..1f72f14 100644
+--- a/drivers/dahdi/wcb4xxp/base.c
++++ b/drivers/dahdi/wcb4xxp/base.c
+@@ -2963,7 +2963,7 @@ static void init_spans(struct b4xxp *b4)
+ static void b4xxp_bottom_half(unsigned long data);
+ 
+ /* top-half interrupt handler */
+-DAHDI_IRQ_HANDLER(b4xxp_interrupt)
++static irqreturn_t b4xxp_interrupt(int irq, void *dev_id)
+ {
+ 	struct b4xxp *b4 = dev_id;
+ 	unsigned char status;
+diff --git a/drivers/dahdi/wct4xxp/base.c b/drivers/dahdi/wct4xxp/base.c
+index 1b37c43..c1d9612 100644
+--- a/drivers/dahdi/wct4xxp/base.c
++++ b/drivers/dahdi/wct4xxp/base.c
+@@ -3941,7 +3941,7 @@ static irqreturn_t _t4_interrupt(int irq, void *dev_id)
+ 	return IRQ_RETVAL(1);
+ }
+ 
+-DAHDI_IRQ_HANDLER(t4_interrupt)
++static irqreturn_t t4_interrupt(int irq, void *dev_id)
+ {
+ 	irqreturn_t ret;
+ 	unsigned long flags;
+@@ -4263,7 +4263,7 @@ out:
+ 	return IRQ_RETVAL(1);
+ }
+ 
+-DAHDI_IRQ_HANDLER(t4_interrupt_gen2)
++static irqreturn_t t4_interrupt_gen2(int irq, void *dev_id)
+ {
+ 	irqreturn_t ret;
+ 	unsigned long flags;
+diff --git a/drivers/dahdi/wctc4xxp/base.c b/drivers/dahdi/wctc4xxp/base.c
+index 55c6026..54e28d3 100644
+--- a/drivers/dahdi/wctc4xxp/base.c
++++ b/drivers/dahdi/wctc4xxp/base.c
+@@ -2731,7 +2731,7 @@ static void deferred_work_func(struct work_struct *work)
+ 	service_rx_ring(wc);
+ }
+ 
+-DAHDI_IRQ_HANDLER(wctc4xxp_interrupt)
++static irqreturn_t wctc4xxp_interrupt(int irq, void *dev_id)
+ {
+ 	struct wcdte *wc = dev_id;
+ 	bool packets_to_process = false;
+diff --git a/drivers/dahdi/wcxb.c b/drivers/dahdi/wcxb.c
+index 4eaba8f..122f9d3 100644
+--- a/drivers/dahdi/wcxb.c
++++ b/drivers/dahdi/wcxb.c
+@@ -478,7 +478,7 @@ static irqreturn_t _wcxb_isr(int irq, void *dev_id)
+ 	return IRQ_HANDLED;
+ }
+ 
+-DAHDI_IRQ_HANDLER(wcxb_isr)
++static irqreturn_t wcxb_isr(int irq, void *dev_id)
+ {
+ 	irqreturn_t ret;
+ 	unsigned long flags;
+diff --git a/include/dahdi/kernel.h b/include/dahdi/kernel.h
+index 363b613..eb3f691 100644
+--- a/include/dahdi/kernel.h
++++ b/include/dahdi/kernel.h
+@@ -60,8 +60,6 @@
+ 
+ #define dahdi_pci_module pci_register_driver
+ 
+-#define DAHDI_IRQ_HANDLER(a) static irqreturn_t a(int irq, void *dev_id)
+-
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+ #define HAVE_NET_DEVICE_OPS
+ #endif
+-- 
+1.7.9.5
+

--- a/patches/dahdi_pci_module.diff
+++ b/patches/dahdi_pci_module.diff
@@ -1,0 +1,127 @@
+From 4af6f69fff19ea3cfb9ab0ff86a681be86045215 Mon Sep 17 00:00:00 2001
+From: Shaun Ruffell <sruffell@sruffell.net>
+Date: Fri, 11 Jan 2019 04:46:35 +0000
+Subject: [PATCH] Remove unnecessary dahdi_pci_module macro.
+
+All supported kernel variations support the same signature for
+registering a PCI module, so we can eliminate the macro.
+
+Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>
+---
+ drivers/dahdi/wcaxx-base.c      |    2 +-
+ drivers/dahdi/wcb4xxp/base.c    |    2 +-
+ drivers/dahdi/wct4xxp/base.c    |    2 +-
+ drivers/dahdi/wctc4xxp/base.c   |    2 +-
+ drivers/dahdi/wctdm24xxp/base.c |    2 +-
+ drivers/dahdi/wcte13xp-base.c   |    2 +-
+ drivers/dahdi/wcte43x-base.c    |    2 +-
+ include/dahdi/kernel.h          |    2 --
+ 8 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git drivers/dahdi/wcaxx-base.c drivers/dahdi/wcaxx-base.c
+index ed7207a..b934960 100644
+--- drivers/dahdi/wcaxx-base.c
++++ drivers/dahdi/wcaxx-base.c
+@@ -4474,7 +4474,7 @@ static int __init wcaxx_init(void)
+ 	if (!battthresh)
+ 		battthresh = fxo_modes[_opermode].battthresh;
+ 
+-	res = dahdi_pci_module(&wcaxx_driver);
++	res = pci_register_driver(&wcaxx_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wcb4xxp/base.c drivers/dahdi/wcb4xxp/base.c
+index 1f72f14..784929f 100644
+--- drivers/dahdi/wcb4xxp/base.c
++++ drivers/dahdi/wcb4xxp/base.c
+@@ -3672,7 +3672,7 @@ static int __init b4xx_init(void)
+ 		printk(KERN_ERR "%s: ERROR: Could not initialize /proc/%s\n",THIS_MODULE->name, PROCFS_NAME);
+ 	}
+ #endif
+-	if (dahdi_pci_module(&b4xx_driver))
++	if (pci_register_driver(&b4xx_driver))
+ 		return -ENODEV;
+ 
+ 	return 0;
+diff --git drivers/dahdi/wct4xxp/base.c drivers/dahdi/wct4xxp/base.c
+index c1d9612..4d0c769 100644
+--- drivers/dahdi/wct4xxp/base.c
++++ drivers/dahdi/wct4xxp/base.c
+@@ -5543,7 +5543,7 @@ static int __init t4_init(void)
+ 			"Please use 'default_linemode' instead.\n");
+ 	}
+ 
+-	res = dahdi_pci_module(&t4_driver);
++	res = pci_register_driver(&t4_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wctc4xxp/base.c drivers/dahdi/wctc4xxp/base.c
+index 54e28d3..3bd56d1 100644
+--- drivers/dahdi/wctc4xxp/base.c
++++ drivers/dahdi/wctc4xxp/base.c
+@@ -4236,7 +4236,7 @@ static int __init wctc4xxp_init(void)
+ 		return -ENOMEM;
+ 	spin_lock_init(&wctc4xxp_list_lock);
+ 	INIT_LIST_HEAD(&wctc4xxp_list);
+-	res = dahdi_pci_module(&wctc4xxp_driver);
++	res = pci_register_driver(&wctc4xxp_driver);
+ 	if (res) {
+ 		kmem_cache_destroy(cmd_cache);
+ 		return -ENODEV;
+diff --git drivers/dahdi/wctdm24xxp/base.c drivers/dahdi/wctdm24xxp/base.c
+index d2e481a..16bf384 100644
+--- drivers/dahdi/wctdm24xxp/base.c
++++ drivers/dahdi/wctdm24xxp/base.c
+@@ -6102,7 +6102,7 @@ static int __init wctdm_init(void)
+ 
+ 	b400m_module_init();
+ 
+-	res = dahdi_pci_module(&wctdm_driver);
++	res = pci_register_driver(&wctdm_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wcte13xp-base.c drivers/dahdi/wcte13xp-base.c
+index 25d4e31..b5f8043 100644
+--- drivers/dahdi/wcte13xp-base.c
++++ drivers/dahdi/wcte13xp-base.c
+@@ -2788,7 +2788,7 @@ static int __init te13xp_init(void)
+ 		return -EINVAL;
+ 	}
+ 
+-	res = dahdi_pci_module(&te13xp_driver);
++	res = pci_register_driver(&te13xp_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git drivers/dahdi/wcte43x-base.c drivers/dahdi/wcte43x-base.c
+index 722d18d..45b0f6c 100644
+--- drivers/dahdi/wcte43x-base.c
++++ drivers/dahdi/wcte43x-base.c
+@@ -3612,7 +3612,7 @@ static int __init t43x_init(void)
+ 		return -EINVAL;
+ 	}
+ 
+-	res = dahdi_pci_module(&t43x_driver);
++	res = pci_register_driver(&t43x_driver);
+ 	if (res)
+ 		return -ENODEV;
+ 
+diff --git include/dahdi/kernel.h include/dahdi/kernel.h
+index eb3f691..1b4ba10 100644
+--- include/dahdi/kernel.h
++++ include/dahdi/kernel.h
+@@ -58,8 +58,6 @@
+
+ #include <linux/poll.h>
+
+-#define dahdi_pci_module pci_register_driver
+-
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+ #define HAVE_NET_DEVICE_OPS
+ #endif
+-- 
+1.7.9.5
+

--- a/patches/dahdi_pci_module.diff
+++ b/patches/dahdi_pci_module.diff
@@ -18,10 +18,10 @@ Signed-off-by: Shaun Ruffell <sruffell@sruffell.net>
  include/dahdi/kernel.h          |    2 --
  8 files changed, 7 insertions(+), 9 deletions(-)
 
-diff --git drivers/dahdi/wcaxx-base.c drivers/dahdi/wcaxx-base.c
+diff --git a/drivers/dahdi/wcaxx-base.c b/drivers/dahdi/wcaxx-base.c
 index ed7207a..b934960 100644
---- drivers/dahdi/wcaxx-base.c
-+++ drivers/dahdi/wcaxx-base.c
+--- a/drivers/dahdi/wcaxx-base.c
++++ b/drivers/dahdi/wcaxx-base.c
 @@ -4474,7 +4474,7 @@ static int __init wcaxx_init(void)
  	if (!battthresh)
  		battthresh = fxo_modes[_opermode].battthresh;
@@ -31,10 +31,10 @@ index ed7207a..b934960 100644
  	if (res)
  		return -ENODEV;
  
-diff --git drivers/dahdi/wcb4xxp/base.c drivers/dahdi/wcb4xxp/base.c
+diff --git a/drivers/dahdi/wcb4xxp/base.c b/drivers/dahdi/wcb4xxp/base.c
 index 1f72f14..784929f 100644
---- drivers/dahdi/wcb4xxp/base.c
-+++ drivers/dahdi/wcb4xxp/base.c
+--- a/drivers/dahdi/wcb4xxp/base.c
++++ b/drivers/dahdi/wcb4xxp/base.c
 @@ -3672,7 +3672,7 @@ static int __init b4xx_init(void)
  		printk(KERN_ERR "%s: ERROR: Could not initialize /proc/%s\n",THIS_MODULE->name, PROCFS_NAME);
  	}
@@ -44,10 +44,10 @@ index 1f72f14..784929f 100644
  		return -ENODEV;
  
  	return 0;
-diff --git drivers/dahdi/wct4xxp/base.c drivers/dahdi/wct4xxp/base.c
+diff --git a/drivers/dahdi/wct4xxp/base.c b/drivers/dahdi/wct4xxp/base.c
 index c1d9612..4d0c769 100644
---- drivers/dahdi/wct4xxp/base.c
-+++ drivers/dahdi/wct4xxp/base.c
+--- a/drivers/dahdi/wct4xxp/base.c
++++ b/drivers/dahdi/wct4xxp/base.c
 @@ -5543,7 +5543,7 @@ static int __init t4_init(void)
  			"Please use 'default_linemode' instead.\n");
  	}
@@ -57,10 +57,10 @@ index c1d9612..4d0c769 100644
  	if (res)
  		return -ENODEV;
  
-diff --git drivers/dahdi/wctc4xxp/base.c drivers/dahdi/wctc4xxp/base.c
+diff --git a/drivers/dahdi/wctc4xxp/base.c b/drivers/dahdi/wctc4xxp/base.c
 index 54e28d3..3bd56d1 100644
---- drivers/dahdi/wctc4xxp/base.c
-+++ drivers/dahdi/wctc4xxp/base.c
+--- a/drivers/dahdi/wctc4xxp/base.c
++++ b/drivers/dahdi/wctc4xxp/base.c
 @@ -4236,7 +4236,7 @@ static int __init wctc4xxp_init(void)
  		return -ENOMEM;
  	spin_lock_init(&wctc4xxp_list_lock);
@@ -70,10 +70,10 @@ index 54e28d3..3bd56d1 100644
  	if (res) {
  		kmem_cache_destroy(cmd_cache);
  		return -ENODEV;
-diff --git drivers/dahdi/wctdm24xxp/base.c drivers/dahdi/wctdm24xxp/base.c
+diff --git a/drivers/dahdi/wctdm24xxp/base.c b/drivers/dahdi/wctdm24xxp/base.c
 index d2e481a..16bf384 100644
---- drivers/dahdi/wctdm24xxp/base.c
-+++ drivers/dahdi/wctdm24xxp/base.c
+--- a/drivers/dahdi/wctdm24xxp/base.c
++++ b/drivers/dahdi/wctdm24xxp/base.c
 @@ -6102,7 +6102,7 @@ static int __init wctdm_init(void)
  
  	b400m_module_init();
@@ -83,10 +83,10 @@ index d2e481a..16bf384 100644
  	if (res)
  		return -ENODEV;
  
-diff --git drivers/dahdi/wcte13xp-base.c drivers/dahdi/wcte13xp-base.c
+diff --git a/drivers/dahdi/wcte13xp-base.c b/drivers/dahdi/wcte13xp-base.c
 index 25d4e31..b5f8043 100644
---- drivers/dahdi/wcte13xp-base.c
-+++ drivers/dahdi/wcte13xp-base.c
+--- a/drivers/dahdi/wcte13xp-base.c
++++ b/drivers/dahdi/wcte13xp-base.c
 @@ -2788,7 +2788,7 @@ static int __init te13xp_init(void)
  		return -EINVAL;
  	}
@@ -96,10 +96,10 @@ index 25d4e31..b5f8043 100644
  	if (res)
  		return -ENODEV;
  
-diff --git drivers/dahdi/wcte43x-base.c drivers/dahdi/wcte43x-base.c
+diff --git a/drivers/dahdi/wcte43x-base.c b/drivers/dahdi/wcte43x-base.c
 index 722d18d..45b0f6c 100644
---- drivers/dahdi/wcte43x-base.c
-+++ drivers/dahdi/wcte43x-base.c
+--- a/drivers/dahdi/wcte43x-base.c
++++ b/drivers/dahdi/wcte43x-base.c
 @@ -3612,7 +3612,7 @@ static int __init t43x_init(void)
  		return -EINVAL;
  	}
@@ -109,10 +109,10 @@ index 722d18d..45b0f6c 100644
  	if (res)
  		return -ENODEV;
  
-diff --git include/dahdi/kernel.h include/dahdi/kernel.h
+diff --git a/include/dahdi/kernel.h b/include/dahdi/kernel.h
 index eb3f691..1b4ba10 100644
---- include/dahdi/kernel.h
-+++ include/dahdi/kernel.h
+--- a/include/dahdi/kernel.h
++++ b/include/dahdi/kernel.h
 @@ -58,8 +58,6 @@
 
  #include <linux/poll.h>

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2,7 +2,7 @@
 
 # PhreakScript
 # (C) 2021-2023 PhreakNet - https://portal.phreaknet.org and https://docs.phreaknet.org
-# v0.2.2 (2023-01-17)
+# v0.2.3 (2023-01-17)
 
 # Setup (as root):
 # cd /usr/local/src
@@ -13,6 +13,7 @@
 # phreaknet install
 
 ## Begin Change Log:
+# 2023-01-17 0.2.3 DAHDI: Correct for DAHDI no longer including CONFIG_PCI and patch cdd6ddd0fd08cb8b7313b16074882439fbb58045 failing
 # 2023-01-17 0.2.2 DAHDI: Correct for DAHDI no longer including CONFIG_PCI and patch 45ac6a30f922f4eef54c0120c2a537794b20cf5c failing
 # 2023-01-12 0.2.1 Asterisk: target 20.1.0
 # 2023-01-07 0.2.0 Asterisk: readd chan_sip support for master
@@ -963,7 +964,7 @@ dahdi_undo() {
 dahdi_custom_undo() {
         printf "Applying custom reverse DAHDI patch: %s\n" "$3"
         wget -q "$4" -O /tmp/$2.patch --no-cache
-        patch -u -p 0 --reverse -i /tmp/$2.patch
+        patch -u -p 1 --reverse -i /tmp/$2.patch
         if [ $? -ne 0 ]; then
                 echoerr "Failed to reverse custom DAHDI patch... this should be reported..."
                 exit 2
@@ -1037,7 +1038,7 @@ git_custom_patch() {
 dahdi_unpurge() { # undo "great purge" of 2018: $1 = DAHDI_LIN_SRC_DIR
 	printf "%s\n" "Reverting patches that removed driver support in DAHDI..."
 	dahdi_custom_undo $1 "dahdi_pci_module" "Remove unnecessary dahdi_pci_module macro" "https://raw.githubusercontent.com/InterLinked1/phreakscript/master/patches/dahdi_pci_module.diff"
-	dahdi_undo $1 "dahdi_irq_handler" "Remove unnecessary DAHDI_IRQ_HANDLER macro" "cdd6ddd0fd08cb8b7313b16074882439fbb58045"
+	dahdi_custom_undo $1 "dahdi_irq_handler" "Remove unnecessary DAHDI_IRQ_HANDLER macro" "https://raw.githubusercontent.com/InterLinked1/phreakscript/master/patches/dahdi_irq_handler.diff"
 	dahdi_undo $1 "devtype" "Remove struct devtype for unsupported drivers" "75620dd9ef6ac746745a1ecab4ef925a5b9e2988"
 	dahdi_undo $1 "wcb" "Remove support for all but wcb41xp wcb43xp and wcb23xp." "29cb229cd3f1d252872b7f1924b6e3be941f7ad3"
 	dahdi_undo $1 "wctdm" "Remove support for wctdm800, wcaex800, wctdm410, wcaex410." "a66e88e666229092a96d54e5873d4b3ae79b1ce3"


### PR DESCRIPTION
In review patch cdd6ddd0fd08cb8b7313b16074882439fbb58045 also updates kernel.h, move this to be a custom patch as well.

Move phreaknet script to 0.2.3