### PR TITLE
Get sources command

### DIFF
--- a/phreaknet.1
+++ b/phreaknet.1
@@ -60,6 +60,9 @@ Install cached PhreakScript man page (may be outdated)
 Install or upgrade Asterisk.
 This is the primary command provided by PhreakScript.
 .TP
+\f[B]source\f[R]
+Download the source code for Asterisk into the current working directory.
+.TP
 \f[B]dahdi\f[R]
 Install or upgrade DAHDI (only).
 Generally this command does not need to be used.

--- a/phreaknet.1.md
+++ b/phreaknet.1.md
@@ -57,6 +57,9 @@ the best Asterisk and DAHDI experience.
 **install**
 : Install or upgrade Asterisk. This is the primary command provided by PhreakScript.
 
+**source**
+: Download and patch source code only, without building or installing. This operates on the current working directory.
+
 **dahdi**
 : Install or upgrade DAHDI (only). Generally this command does not need to be used. To install Asterisk with DAHDI, use the install command and provide the -d or --dahdi option instead.
 

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -534,7 +534,7 @@ install_prereq() {
 		if [ "$ENHANCED_INSTALL" = "1" ]; then
 			apt-get dist-upgrade -y
 		fi
-		apt-get install -y wget curl libcurl4-openssl-dev dnsutils bc git mpg123 # necessary for install and basic operation.
+		apt-get install -y wget curl libcurl4-openssl-dev dnsutils bc git subversion mpg123 # necessary for install and basic operation.
 		if [ "$ENHANCED_INSTALL" = "1" ]; then # not strictly necessary, but likely useful on many Asterisk systems.
 			apt-get install -y ntp tcpdump festival
 		fi


### PR DESCRIPTION
This adds a new command to phreaknet, called "source", which will execute the steps for downloading and patching asterisk source code. This operates on the current working directory, instead of /usr/src. It is not necessary to execute this command as root, provided that the prerequisites of git and subversion are already installed. Code that also needs to be used by the "install" command has been factored out into a function called get_source. Man page files were also update to include the new command.
This command will probably not get used often by users, and is aimed a providing a way to consistently get source and patches for inclusion in a debian packaging system. 
The only existing command that should be affected by the changes is the "install" command. I have only regression tested the "install" command with -s -t -d flags, and with and without the -f flag. 