### PR TITLE
Fixes for building on Pi for app_rpt

### DIFF
--- a/patches/dahdi_tools_inline_get_ver.diff
+++ b/patches/dahdi_tools_inline_get_ver.diff
@@ -1,0 +1,11 @@
+--- dahdi-tools-3.2.0/xpp/echo_loader.c.orig	2023-07-06 13:27:46.393684030 -0400
++++ dahdi-tools-3.2.0/xpp/echo_loader.c	2023-07-06 13:28:17.053200388 -0400
+@@ -564,7 +564,7 @@
+ 	return cOCT6100_ERR_OK;
+ }
+ 
+-inline int get_ver(struct astribank *astribank)
++static inline int get_ver(struct astribank *astribank)
+ {
+ 	return spi_send(astribank, 0, 0, 1, 1);
+ }

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1226,6 +1226,9 @@ install_dahdi() {
 
 	# New Features
 
+	# fix static inline function get_ver (GitHub dahdi-tools #11)
+	phreak_fuzzy_patch "dahdi_tools_inline_get_ver.diff"	
+
 	# hearpulsing
 	if [ "$EXTRA_FEATURES" = "1" ]; then
 		git_patch "hearpulsing-dahtool.patch" # hearpulsing
@@ -1291,7 +1294,9 @@ install_dahdi() {
 	make && make install
 
 	# Wanpipe
-	install_wanpipe
+	if [ `uname -m` != "armv7l" ] && [ `uname -m` != "aarch64" ]; then
+		install_wanpipe
+	fi
 
 	service dahdi restart
 }

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1345,7 +1345,7 @@ install_wanpipe() {
 	if [ $? -ne 0 ]; then
 		# XXX Should have an option to fail here forcibly, for testing.
 		echoerr "wanpipe install failed: unsupported kernel?"
-		echo "installation of other items will proceed without exiting following this error"
+		printf "Installation of other items will proceed\n"
 		sleep 1
 	else
 		wanrouter stop

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1294,9 +1294,7 @@ install_dahdi() {
 	make && make install
 
 	# Wanpipe
-	if [ `uname -m` != "armv7l" ] && [ `uname -m` != "aarch64" ]; then
-		install_wanpipe
-	fi
+	install_wanpipe
 
 	service dahdi restart
 }
@@ -1347,8 +1345,8 @@ install_wanpipe() {
 	if [ $? -ne 0 ]; then
 		# XXX Should have an option to fail here forcibly, for testing.
 		echoerr "wanpipe install failed: unsupported kernel?"
+		echo "installation of other items will proceed without exiting following this error"
 		sleep 1
-		#exit 2
 	else
 		wanrouter stop
 		wanrouter start


### PR DESCRIPTION
- Apply patch for dahdi-tools for absence of `-O` optimizations in the build process that leads to an error with get_ver
- Don't install wanpipe on armv7l and aarch64 platforms