### PR TITLE
PATCH: ast_variable_update() does not play well with templates

### DIFF
--- a/patches/config_c_fix_template_writing.patch
+++ b/patches/config_c_fix_template_writing.patch
@@ -1,0 +1,25 @@
+diff --git a/main/config.c b/main/config.c
+index e7ac4149a6..e81d3afced 100644
+--- a/main/config.c
++++ b/main/config.c
+@@ -1533,13 +1533,19 @@ int ast_variable_delete(struct ast_category *category, const char *variable, con
+ int ast_variable_update(struct ast_category *category, const char *variable,
+ 						const char *value, const char *match, unsigned int object)
+ {
+-	struct ast_variable *cur, *prev=NULL, *newer=NULL;
++	struct ast_variable *cur, *prev=NULL, *newer=NULL, *matchvar = NULL;
+ 
+ 	for (cur = category->root; cur; prev = cur, cur = cur->next) {
+ 		if (strcasecmp(cur->name, variable) ||
+ 			(!ast_strlen_zero(match) && strcasecmp(cur->value, match)))
+ 			continue;
++		matchvar = cur;
++	}
+ 
++	for (cur = category->root; cur; prev = cur, cur = cur->next) {
++		if (cur != matchvar) {
++			continue;
++		}
+ 		if (!(newer = ast_variable_new(variable, value, cur->file)))
+ 			return -1;
+ 

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1929,6 +1929,7 @@ phreak_patches() { # $1 = $PATCH_DIR, $2 = $AST_SRC_DIR
 
 	## Unmerged patches: remove once merged
 	git_patch "config_c_fix_template_inheritance_overrides.patch" # config.c: fix template inheritance/overrides
+	git_patch "config_c_fix_template_writing.patch" # config.c: fix template inheritance/overrides
 
 	if [ $AST_MAJOR_VER -lt 21 ]; then
 		if [ "$EXTERNAL_CODECS" = "1" ]; then


### PR DESCRIPTION
The "config_c_fix_template_inheritance_overrides.patch" addresses a issue with how ast_variable_retrieve() interacts with templates. There is a similar issue with ast_variable_update(). This "patch" addresses the problem.