### PR TITLE
install: Improve robustness of various install procedures.

### DIFF
--- a/configs/samples/res_alarmsystem.conf.sample
+++ b/configs/samples/res_alarmsystem.conf.sample
@@ -14,44 +14,44 @@
 
 ; *** Server configuration
 
-[general]
-bindport=4589 ; UDP port to which alarm server will bind, if any servers are enabled.
+;[general]
+;bindport=4589 ; UDP port to which alarm server will bind, if any servers are enabled.
 ;bindaddr=0.0.0.0
 
-[myserver] ; Defines an alarm server to which alarm clients can report.
-type = server
-ip_loss_tolerance = 60 ; Number of seconds the server will tolerate not receiving pings from clients before considering
+;[myserver] ; Defines an alarm server to which alarm clients can report.
+;type = server
+;ip_loss_tolerance = 60 ; Number of seconds the server will tolerate not receiving pings from clients before considering
                        ; IP connectivity to a client to have been lost (which will trigger the internet_lost alarm).
-contexts = myserver-contexts ; A config section which defines dialplan contexts to execute for each alarm event
-logfile = /var/log/asterisk/alarm_server.log ; Log file for this server
+;contexts = myserver-contexts ; A config section which defines dialplan contexts to execute for each alarm event
+;logfile = /var/log/asterisk/alarm_server.log ; Log file for this server
 
-[clients] ; Special section defining clients authorized to report to this server
+;[clients] ; Special section defining clients authorized to report to this server
 ;A101 = 1D7B ; one entry for each client, with client ID as the key and client PIN as the value
 
 ; *** Client configuration
 
-[myclient] ; Each alarm client is defined in its own section
-type = client
-client_id = A101 ; Unique, telenumeric ID (0-9,A-D) for this client. Should be unique across all clients that report to a server.
+;[myclient] ; Each alarm client is defined in its own section
+;type = client
+;client_id = A101 ; Unique, telenumeric ID (0-9,A-D) for this client. Should be unique across all clients that report to a server.
                  ; Note that there is no security mechanism to restrict reporting aside from the client ID.
 				 ; Therefore, if the alarm server is exposed to the Internet, you may wish to use long, hard-to-guess client IDs
 				 ; to prevent spoofed reports, or lock down your firewall accordingly.
 ;client_pin=1D794B61 ; PIN, if required by server for authentication
-server_ip = 127.0.0.1:4589 ; IP/port to reach alarm server over IP
-server_dialstr = DAHDI/g1/*70w18005551212 ; A dial string for "POTS phone failover" to reach alarm server if unable to by IP. If you need to use dial options, use a Local channel to encapsulate the Dial() call.
+;server_ip = 127.0.0.1:4589 ; IP/port to reach alarm server over IP
+;server_dialstr = DAHDI/g1/*70w18005551212 ; A dial string for "POTS phone failover" to reach alarm server if unable to by IP. If you need to use dial options, use a Local channel to encapsulate the Dial() call.
    ; The server should call AlarmEventReceiver() (NOT AlarmReceiver() !!!) when receiving such a call.
    ; NOTE: When reporting an alarm trigger, the line will stay open until disarm_delay has been reached, to avoid making multiple calls in succession
-phone_hangup_delay = 45 ; Number of seconds to keep phone failover line open upon reporting event for reporting further events in that time.
+;phone_hangup_delay = 45 ; Number of seconds to keep phone failover line open upon reporting event for reporting further events in that time.
                         ; It is recommended this setting be at least 10-15 seconds, so that if phone failover is being used,
                         ; a single phone call is sufficient to report sensor trigger and alarm disarm events, rather than dialing up a second time to report this event.
                         ; You may want to tweak this based on the cost of each call, cost per minute, and the acceptable amount of delay in setting up a call. Default is 45.
-ping_interval = 4 ; How often to ping the server
-egress_delay = 15 ; number of seconds grace period to exit without re-triggering alarm
-contexts = myclient-contexts ; A config section which defines dialplan contexts to execute for each alarm event
-logfile = /var/log/asterisk/alarm_myclient.log ; Log file to which to log alarm events.
+;ping_interval = 4 ; How often to ping the server
+;egress_delay = 15 ; number of seconds grace period to exit without re-triggering alarm
+;contexts = myclient-contexts ; A config section which defines dialplan contexts to execute for each alarm event
+;logfile = /var/log/asterisk/alarm_myclient.log ; Log file to which to log alarm events.
 
-[myclient-contexts]
-type = contexts
+;[myclient-contexts]
+;type = contexts
 ; In this section, the key is the name of the alarm event for which the specified dialplan will be executed,
 ; and the value is the dialplan [exten@]context to execute. If exten is omitted, s will be used. The priority will always be 1.
 ;
@@ -64,20 +64,20 @@ type = contexts
 ; internet_lost = iplost@myclientalarm ; Internet connectivity to alarm peer lost
 ; internet_restored = iprestored@myclientalarm ; Internet connectivity to alarm peer restored
 
-[door] ; Section defining a door sensor
-type = sensor
-sensor_id = 1 ; Unique, numeric ID for this sensor. Should be unique across all sensors belongng to all clients that report to a server.
-client = myclient ; Client associated with this sensor
-device = DAHDI/23 ; if specified, then arg2 to AlarmSensor is optional since we can use the channel to determine which sensor was activated
+;[door] ; Section defining a door sensor
+;type = sensor
+;sensor_id = 1 ; Unique, numeric ID for this sensor. Should be unique across all sensors belongng to all clients that report to a server.
+;client = myclient ; Client associated with this sensor
+;device = DAHDI/23 ; if specified, then arg2 to AlarmSensor is optional since we can use the channel to determine which sensor was activated
                    ; (This way, the same context can be specified for all sensors, using immediate=yes in chan_dahdi.conf)
-disarm_delay = 45 ; Number of seconds grace period permitted to disarm an active alarm after this sensor triggers before it is considered a breach.
+;disarm_delay = 45 ; Number of seconds grace period permitted to disarm an active alarm after this sensor triggers before it is considered a breach.
                   ; Default is 60.
 
-[keypad] ; Section defining alarm keypad settings. An alarm keypad can be instantiated by using AlarmKeypad()
-type = keypad
-client = myclient ; Client associated with these keypad settings
-keypad_device = PJSIP/Polycom ; dial string for alarm keypad endpoints to autodial when alarm is triggered. Use a Local channel for predial options to autoanswer.
-pin = 1234 ; Hardcoded PIN which must be entered to disarm the alarm. Multiple PINs can be permitted by providing multiple comma-separated PINs.
-audio = custom/siren ; An optional audio file to play while waiting for the alarm to be disarmed. By default, a tone is played.
-cid_num = DISARM SYSTEM NOW ; Caller ID number to use for outgoing calls to the keypad device
-cid_name = ALARM PANEL ; Caller ID name to use for outgoing calls to the keypad device
+;[keypad] ; Section defining alarm keypad settings. An alarm keypad can be instantiated by using AlarmKeypad()
+;type = keypad
+;client = myclient ; Client associated with these keypad settings
+;keypad_device = PJSIP/Polycom ; dial string for alarm keypad endpoints to autodial when alarm is triggered. Use a Local channel for predial options to autoanswer.
+;pin = 1234 ; Hardcoded PIN which must be entered to disarm the alarm. Multiple PINs can be permitted by providing multiple comma-separated PINs.
+;audio = custom/siren ; An optional audio file to play while waiting for the alarm to be disarmed. By default, a tone is played.
+;cid_num = DISARM SYSTEM NOW ; Caller ID number to use for outgoing calls to the keypad device
+;cid_name = ALARM PANEL ; Caller ID name to use for outgoing calls to the keypad device


### PR DESCRIPTION
* res_alarmsystem.conf.sample: Comment out config, to avoid newly built systems having this module enabled by default.
* wanpipe: Install missing pre-reqs if needed.
* wanpipe: Use more proper arguments for Setup script.
* wanpipe: Don't ignore install failures. wanpipe is not installed by default anymore and should compile successfully on kernels through 6.1.0. To work around this, users can force continuing the install if needed using --force, or install on kernels <= 6.1.0.
* CI: Build wanpipe in one of the Debian 12 CI builds.
* install: Disable yappcap from building if the test suite fails to build initially. This is deprecated and not needed for all tests.
* install: Fix misimplementation of --fast flag. A nice value was set, but not actually used anywhere, which actually resulted in builds being slower with this flag. Also pull this out to the top of the script, so that all compilation is affected.

PHREAKSCRIPT-42 #close
PHREAKSCRIPT-48 #close