### PR TITLE
PATCH: config.c: problems with #tryinclude statements, whitespace

### DIFF
--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2207,6 +2207,8 @@ phreak_patches() { # $1 = $PATCH_DIR, $2 = $AST_SRC_DIR
 	asterisk_pr_unconditional 917 # FreeBSD compilation fixes
 	git_patch "config_c_fix_template_inheritance_overrides.patch" # config.c: fix template inheritance/overrides
 	git_patch "config_c_fix_template_writing.patch" # config.c: fix template inheritance/overrides
+	asterisk_pr_unconditional 918 # config.c #tryinclude fixes
+	asterisk_pr_unconditional 971 # config.c fix issues w/ whitespace in comments
 
 	if [ $AST_MAJOR_VER -lt 21 ]; then
 		if [ "$EXTERNAL_CODECS" = "1" ]; then


### PR DESCRIPTION
Creating phreaknet patches for the following Asterisk issues / pull requests :

1. config_c_fix_tryinclude.patch
    - [Issue #920](https://github.com/asterisk/asterisk/issues/920)
    - [PR #918](https://github.com/asterisk/asterisk/pull/918)

    Correct an issue in ast_config_text_file_save2() when updating configuration files with "#tryinclude" statements. The API currently replaces "#tryinclude" with "#include". The API also creates empty template files if the referenced files do not exist. This patch resolves these problems.

2. config_c_fix_whitespace.patch
    - [Issue #970](https://github.com/asterisk/asterisk/issues/970)
    - [PR #971](https://github.com/asterisk/asterisk/pull/971)

    Configurations loaded with the ast_config_load2() API and later written out with ast_config_text_file_save2() will have any leading whitespace stripped away.  The APIs should make reasonable efforts to maintain the content and formatting of the configuration files.