### PR TITLE
install: Add flag to auto-set KVERS.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Build DAHDI and Asterisk
         run: |
           ./phreaknet.sh make
-          KVERS="6.13.0-0.rc2" phreaknet install --fast --dahdi --drivers --devmode
+          phreaknet install --fast --dahdi --autokvers --drivers --devmode
   alma-9-5:
     runs-on: ubuntu-24.04
     name: Alma Linux 9.5
@@ -198,7 +198,7 @@ jobs:
       - name: Build DAHDI and Asterisk
         run: |
           ./phreaknet.sh make
-          KVERS="5.14.0-503.15.1" phreaknet install --fast --dahdi --drivers --devmode
+          phreaknet install --fast --dahdi --autokvers --drivers --devmode
   rocky-9:
     runs-on: ubuntu-24.04
     name: Rocky Linux 9.3
@@ -208,7 +208,7 @@ jobs:
       - name: Build DAHDI and Asterisk
         run: |
           ./phreaknet.sh make
-          KVERS="5.14.0-503.16.1" phreaknet install --fast --dahdi --drivers --devmode
+          phreaknet install --fast --dahdi --autokvers --drivers --devmode
   rocky-8:
     runs-on: ubuntu-24.04
     name: Rocky Linux 8.9
@@ -218,7 +218,7 @@ jobs:
       - name: Build DAHDI and Asterisk
         run: |
           ./phreaknet.sh make
-          KVERS="4.18.0-553.32.1" phreaknet install --fast --dahdi --drivers --devmode
+          phreaknet install --fast --dahdi --autokvers --drivers --devmode
   opensuse:
     runs-on: ubuntu-24.04
     name: openSUSE Tumbleweed

--- a/phreaknet.1.md
+++ b/phreaknet.1.md
@@ -291,6 +291,12 @@ The following options may be used with the **install** command.
 **--drivers**
 : Also install DAHDI drivers removed in 2018 by Sangoma
 
+**--generic**
+: Use generic kernel headers that do not match the installed kernel version
+
+**--autokvers**
+: Automatically pass the appropriate value for KVERS for DAHDI compilation (only needed on non-Debian systems)
+
 **--experimental**
 : Install experimental features that may not be production ready
 

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -265,6 +265,7 @@ SCRIPT_UPSTREAM="$PATCH_DIR/phreaknet.sh"
 DEBUG_LEVEL=0
 FREEPBX_GUI=0
 GENERIC_HEADERS=0
+AUTOSET_KVERS=0
 EXTERNAL_CODECS=0
 RTPULSING=1
 HEARPULSING=1
@@ -580,6 +581,7 @@ Options:
        --sccp         install: Install chan_sccp channel driver (Cisco Skinny)
        --drivers      install: Also install DAHDI drivers removed in 2018
        --generic      install: Use generic kernel headers that do not match the installed kernel version
+       --autokvers    install: Automatically pass the appropriate value for KVERS for DAHDI compilation (only needed on non-Debian systems)
        --extcodecs    install: Specify this if any external codecs are being or will be installed
        --freepbx      install: Install FreePBX GUI (not recommended)
        --manselect    install: Manually run menuselect yourself
@@ -1692,6 +1694,10 @@ install_dahdi() {
 				fi
 				if [ "$KERNEL_DEVEL_VERSION" != "$kernel_ver" ]; then
 					echoerr "kernel-devel mismatch still present? ($KERNEL_DEVEL_VERSION != $kernel_ver)"
+					if [ "$AUTOSET_KVERS" = "1" ]; then
+						printf "Auto-setting KVERS=%s\n" "$KERNEL_DEVEL_VERSION"
+						KVERS="$KERNEL_DEVEL_VERSION"
+					fi
 					if [ "$KVERS" != "" ]; then
 						# Kernel version override for GitHub CI builds, where the available headers on Fedora-based distros
 						# do not match the running kernel. This probably would not run successfully, but in this case,
@@ -2896,7 +2902,7 @@ else
 fi
 
 FLAG_TEST=0
-PARSED_ARGUMENTS=$(getopt -n phreaknet -o bc:u:dfhostu:v:w -l backtraces,cc:,dahdi,force,flag-test,help,sip,testsuite,user:,version:,weaktls,alsa,cisco,sccp,clli:,debug:,devmode,disa:,drivers,experimental,extcodecs,fast,freepbx,generic,lightweight,api-key:,rotate,audit,boilerplate,upstream:,manselect,minimal,vanilla,wanpipe -- "$@")
+PARSED_ARGUMENTS=$(getopt -n phreaknet -o bc:u:dfhostu:v:w -l backtraces,cc:,dahdi,force,flag-test,help,sip,testsuite,user:,version:,weaktls,alsa,cisco,sccp,clli:,debug:,devmode,disa:,drivers,experimental,extcodecs,fast,freepbx,generic,autokvers,lightweight,api-key:,rotate,audit,boilerplate,upstream:,manselect,minimal,vanilla,wanpipe -- "$@")
 VALID_ARGUMENTS=$?
 if [ "$VALID_ARGUMENTS" != "0" ]; then
 	usage
@@ -2941,6 +2947,7 @@ while true; do
 		--fast ) FAST_COMPILE=1; shift ;;
 		--freepbx ) FREEPBX_GUI=1; shift ;;
 		--generic ) GENERIC_HEADERS=1; shift ;;
+		--autokvers ) AUTOSET_KVERS=1; shift ;;
 		--lightweight ) LIGHTWEIGHT=1; shift ;;
 		--api-key ) INTERLINKED_APIKEY=$2; shift 2;;
 		--rotate ) ASTKEYGEN=1; shift ;;


### PR DESCRIPTION
For a little while, we've been manually setting KVERS in the CI definitions (main.yml) in order to successfully build against the provided kernel in the CI. However, the version updates over time, so this breaks frequently. Since we just want to match the version actually available, add a flag to automatically set KVERS to the available kernel header version, and just use that instead.