### PR TITLE
Don’t try to install hostname on FreeBSD

### DIFF
--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -455,9 +455,8 @@ if [ "$PAC_MAN" = "pacman" ]; then
 	if ! which "hostname" > /dev/null; then
 		install_package "net-tools"
 	fi
-elif [ "$PAC_MAN" = "pkg" ]; then
-	# `hostname' is part of base; do not install
-else
+elif [ "$PAC_MAN" != "pkg" ]; then
+	# `hostname' is part of base on FreeBSD; do not install
 	ensure_installed "hostname"
 fi
 


### PR DESCRIPTION
The `hostname` command is part of the base OS; moreover, a package with that name doesn’t exist in ports.  This is the only thing I had to change to get `./phreaknet.sh make` to run on FreeBSD 14.3-RELEASE.