### PR TITLE
phreaknet.sh: patches to kernel header and DAHDI installation for Raspberry Pi OS 13+

### DIFF
--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2045,7 +2045,8 @@ install_kernel_headers() {
 		# Check that the kernel sources are really present
 		# /usr/src/linux-headers-* on Debian
 		# /usr/src/kernels on Rocky Linux
-		numkernheaders=$( ls /usr/src/linux-headers-* /usr/src/kernels/* 2>/dev/null | wc -w )
+		# /usr/src/linux-* on openSUSE
+		numkernheaders=$( ls /usr/src/linux-headers-* /usr/src/kernels/* /usr/src/linux-* 2>/dev/null | wc -w )
 		if [ "$numkernheaders" = "0" ]; then
 			echoerr "Kernel headers do not appear to be installed... compilation will likely fail"
 			sleep 2

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1075,7 +1075,7 @@ install_prereq() {
 			fi
 		fi
 	elif [ "$PAC_MAN" = "zypper" ]; then
-		PREREQ_PACKAGES="$PREREQ_PACKAGES git-core make patch gawk autoconf subversion bzip2 gcc-c++"
+		PREREQ_PACKAGES="$PREREQ_PACKAGES git-core make patch gawk autoconf automake libtool subversion bzip2 gcc-c++"
 		if [ "$CHAN_DAHDI" = "1" ]; then
 			PREREQ_PACKAGES="$PREREQ_PACKAGES newt-devel dwarves"
 		fi
@@ -4216,6 +4216,10 @@ elif [ "$cmd" = "install" ]; then
 	if [ "$CHAN_DAHDI" = "1" ]; then
 		echog "Note that DAHDI was installed and requires a reboot (or hotswap of kernel modules, e.g. phreaknet restart) before it can be used."
 		echog "Note that you will need to manually configure /etc/dahdi/system.conf appropriately for your spans."
+		if [ "$PAC_MAN" = "zypper" ]; then
+			echog "Additionally, since you appear to be using openSUSE/SUSE Linux Enterprise, you will need to enable the loading of unsupported kernel modules."
+			echog "See https://support.scc.suse.com/s/kb/Enable-loading-of-unsupported-kernel-modules for details on how to do this."
+		fi
 	fi
 	if [ "$FREEPBX_GUI" = "1" ]; then
 		printf "%s\n" "Installation of FreePBX GUI will begin in 5 seconds..."

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -328,6 +328,8 @@ elif [ -f /etc/redhat-release ]; then
 	PAC_MAN="yum"
 elif [ "$OS_DIST_INFO" = "SLES" ]; then
 	PAC_MAN="zypper"
+elif [ "$OS_DIST_INFO" = "openSUSE Leap" ]; then
+	PAC_MAN="zypper"
 elif [ "$OS_DIST_INFO" = "openSUSE Tumbleweed" ]; then
 	PAC_MAN="zypper"
 elif [ -r /etc/arch-release ]; then

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2226,9 +2226,15 @@ install_dahdi() {
 	# Check if this directory exists, otherwise try looking in /usr/src
 	# This is for openSUSE compatibility
 	if [ ! -d "$KBUILD_DIR" ]; then
-		KERNEL_VER=$( uname -r | cut -d'-' -f1-2)
-		printf "No build directory found in /usr/lib, checking /usr/src for ${KERNEL_VER}...\n"
-		KBUILD_DIR="/usr/src/linux-${KERNEL_VER}"
+		# RPi OS/Debian 13 use the full kernel version string for their kbuild directory,
+		# So we'll check for that first before checking /usr/src.
+		KERNEL_VER=$( uname -r | cut -d'-' -f1-1)
+		printf "No /usr/lib/linux-kbuild-major.minor dir, checking for dir with full kernel version (${KERNEL_VER})...\n"
+		KBUILD_DIR="/usr/lib/linux-kbuild-${KERNEL_VER}"
+		if [ ! -d "$KBUILD_DIR" ]; then
+			printf "No build directory found in /usr/lib, checking /usr/src for ${KERNEL_VER}...\n"
+			KBUILD_DIR="/usr/src/linux-${KERNEL_VER}"
+		fi
 	fi
 	if [ -d "$KBUILD_DIR" ]; then
 		MODFINAL_FILE="${KBUILD_DIR}/scripts/Makefile.modfinal"

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2215,6 +2215,13 @@ install_dahdi() {
 	KERNEL_MM=$( uname -r | cut -d'.' -f1-2 )
 	printf "Kernel major.minor version is %s\n" "$KERNEL_MM"
 	KBUILD_DIR="/usr/lib/linux-kbuild-${KERNEL_MM}"
+	# Check if this directory exists, otherwise try looking in /usr/src
+	# This is for openSUSE compatibility
+	if [ ! -d "$KBUILD_DIR" ]; then
+		KERNEL_VER=$( uname -r | cut -d'-' -f1-2)
+		printf "No build directory found in /usr/lib, checking /usr/src for ${KERNEL_VER}..."
+		KBUILD_DIR="/usr/src/linux-${KERNEL_VER}"
+	fi
 	if [ -d "$KBUILD_DIR" ]; then
 		MODFINAL_FILE="${KBUILD_DIR}/scripts/Makefile.modfinal"
 		if [ -f "$MODFINAL_FILE" ]; then

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2005,7 +2005,8 @@ install_kernel_headers() {
 				echog "kernel-devel is matched with kernel. Package provides $KERNEL_DEVEL_VERSION, and running kernel is $kernel_ver"
 			fi
 		elif [ "$PAC_MAN" = "zypper" ]; then
-			install_package "kmod kernel-source"
+			# There are multiple kernel-*-devel packages in the openSUSE repos. The default one should be a safe assumption.
+			install_package "kmod kernel-source kernel-devel kernel-default-devel"
 		elif [ "$PAC_MAN" = "pacman" ]; then
 			install_package "kmod linux-headers"
 		elif [ "$PAC_MAN" = "apk" ]; then

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1075,7 +1075,7 @@ install_prereq() {
 			fi
 		fi
 	elif [ "$PAC_MAN" = "zypper" ]; then
-		PREREQ_PACKAGES="$PREREQ_PACKAGES git-core make patch gawk subversion bzip2 gcc-c++"
+		PREREQ_PACKAGES="$PREREQ_PACKAGES git-core make patch gawk autoconf subversion bzip2 gcc-c++"
 		if [ "$CHAN_DAHDI" = "1" ]; then
 			PREREQ_PACKAGES="$PREREQ_PACKAGES newt-devel dwarves"
 		fi

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -2219,7 +2219,7 @@ install_dahdi() {
 	# This is for openSUSE compatibility
 	if [ ! -d "$KBUILD_DIR" ]; then
 		KERNEL_VER=$( uname -r | cut -d'-' -f1-2)
-		printf "No build directory found in /usr/lib, checking /usr/src for ${KERNEL_VER}..."
+		printf "No build directory found in /usr/lib, checking /usr/src for ${KERNEL_VER}...\n"
 		KBUILD_DIR="/usr/src/linux-${KERNEL_VER}"
 	fi
 	if [ -d "$KBUILD_DIR" ]; then

--- a/phreaknet.sh
+++ b/phreaknet.sh
@@ -1767,7 +1767,14 @@ linux_headers_install_apt() {
 	if [ $? -ne 0 ]; then
 		apt-get install -y linux-headers-`uname -r`
 	else
-		apt-get install -y raspberrypi-kernel-headers
+		# raspberrypi-kernel-headers isn't used on Raspberry Pi OS 13+, instead it uses a more normal linux-headers-* package.
+		# If we are on Debian 13 or later, we will install that package instead.
+		DEB_VERSION=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+		if [ $DEB_VERSION -ge 13 ]; then
+			apt-get install -y linux-headers-`uname -r`
+		else
+			apt-get install -y raspberrypi-kernel-headers
+		fi
 	fi
 	if [ $? -ne 0 ]; then
 		kernel=`uname -r`


### PR DESCRIPTION
These commits make three changes to phreaknet.sh:

1. RPi OS 13 replaced the old "raspberrypi-kernel-headers" package with a more standard "linux-headers-*" package. Since PhreakScript only checked for the old package name, kernel header installation will fail on RPi OS 13+. A check for this (or a newer version) has been added to ensure the correct package is installed (which it usually is out of the box, from what I can tell).
2. The kbuild directory is still in /usr/lib (unlike openSUSE), but it not uses the full kernel and local version. And like openSUSE, the same kernel Makefile patch fails, as it can't find the kbuild directory. This directory format is now checked for if a major-minor directory cannot be found, and, failing that, a full-version directory in /usr/src.
3. Related to 2, I discovered the line that gets the kernel version would leave part of the distribution-specific string if there were multiple hyphens. I tweaked this line to make sure that we only get the kernel version and local version string (i.e. the part of the kernel version string that is separated from the version number by a plus), which is what is used for the kbuild directory name.